### PR TITLE
lbfgsb type narrowing

### DIFF
--- a/pyttb/gcp/optimizers.py
+++ b/pyttb/gcp/optimizers.py
@@ -494,8 +494,7 @@ class LBFGSB:
             self._solver_kwargs["maxiter"],
             self._solver_kwargs.get("callback", None),  # callback may be pruned in ctor
         )
-        # Unregister monitor in case of re-use
-        self._solver_kwargs["callback"] = monitor.callback
+        self._solver_kwargs["callback"] = monitor
 
         final_vector, final_f, lbfgsb_info = fmin_l_bfgs_b(
             lbfgsb_func_grad,
@@ -509,6 +508,7 @@ class LBFGSB:
 
         lbfgsb_info["final_f"] = final_f
         lbfgsb_info["callback"] = vars(monitor)
+        # Unregister monitor in case of re-use
         self._solver_kwargs = monitor.callback
 
         # TODO big print output


### PR DESCRIPTION
1. Uses the overengineered TypedDict to track the solver_kwargs entry types through the dictionary. The alternative is to do type narrowing when we pull the keys out of the dictionary. We could also create a dataclass for the LBFGSB args and just pass that whole structure in to the class to reduce the duplication of the arg types in the constructor and typed dict.
2. This resets the solver_kwargs callback back to the original callback rather than clearing it out. Which I believe is the correct approach.

<!-- readthedocs-preview pyttb start -->
----
📚 Documentation preview 📚: https://pyttb--2.org.readthedocs.build/en/2/

<!-- readthedocs-preview pyttb end -->